### PR TITLE
Add explicitly Import-Module in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The script:
 
 ```powershell
 # Import the script
-PS> .\livediff.ps1
+PS> Import-Module .\livediff.ps1
 # Launch the live view
 PS> Show-LiveDiff
 ...


### PR DESCRIPTION
Import-module should be used in the following cases:
- $PSModuleAutoloadingPreference is set to "none"
- the module file is not in a path included in $PSModule
- different modules with the same name are located in different paths